### PR TITLE
Fix leftover PIFork naming in example config template

### DIFF
--- a/module/example.fgp.prop
+++ b/module/example.fgp.prop
@@ -1,4 +1,4 @@
-# Rename to custom.pif.prop once completed
+# Rename to custom.fgp.prop once completed
 #
 # These are the current suggested defaults but you may add as many other fields/properties as needed
 #


### PR DESCRIPTION
module/example.fpg.prop had a transposed filename and told users to rename it to custom.pif.prop, a leftover from the PlayIntegrityFork scripts this module's config was adapted from. The actual runtime (main.cpp) only looks for custom.fgp.prop/custom.fgp.json, so following the file's own instructions would silently produce a config that never gets picked up.