### PR TITLE
Add WebUI profile selection: data saver (Pixel 4 XL) vs. original quality

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,6 +30,14 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
+    - name: Run native config path unit test
+      run: |
+        clang++ -std=c++23 -fno-exceptions -fno-rtti tests/test_config_path.cpp -o /tmp/test_config_path
+        /tmp/test_config_path
+
+    - name: Run WebUI unit test
+      run: node --test tests/test_webui.mjs
+
     - name: Build with Gradle
       run: ./gradlew --warning-mode all assembleRelease
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add a WebUI (KernelSU/KernelSU Next/APatch) to pick the spoofed device profile: Original quality (Pixel) or Data saver (Pixel 4 XL, `coral`), without hand-editing config files.
+
 ## Google Photos Unlimited v4
 
 - Fix Pixel-exclusive system services breaking: the module no longer hides `pixel_experience_<year>_exclusive.xml` sysconfig files system-wide on any device/ROM ([#19](https://github.com/Rev4N1/GPhotosUnlimited/issues/19))

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ After installing (and rebooting), **back up a new photo**, then open that photo 
 
 If a newly backed-up photo *does* count against your storage, clear Google Photos app data and reboot, then take another photo and check again.
 
+## Choosing the backup quality
+
+The module ships two spoofing profiles:
+
+- **Original quality** (default) - spoofs a 2016 Pixel. Grants the unlimited "Original quality" backup tier.
+- **Data saver** - spoofs a Pixel 4 XL. Grants the unlimited "Storage saver" backup tier.
+
+On KernelSU, KernelSU Next or APatch, open the module's WebUI (from the module list, tap the module) and pick a profile; a "Reboot now" button appears whenever the picked profile hasn't taken effect yet, since only a reboot applies it. Magisk has no built-in WebUI host, so Magisk users need [MMRL](https://github.com/MMRLApp/MMRL) or [KsuWebUIStandalone](https://github.com/5ec1cff/KsuWebUIStandalone) to open `webroot/index.html`.
+
+If you have a `custom.fgp.prop` or `custom.fgp.json` in the module directory, it always takes priority over the WebUI selection - the WebUI shows a notice and disables itself in that case.
+
 ## About 'custom.app_replace_list.txt' file
 
 You can customize the included default [app_replace_list.txt](https://raw.githubusercontent.com/Rev4N1/GPhotosUnlimited/main/module/app_replace_list.txt) from the module directory (/data/adb/modules/unlimitedphotos) then rename it to custom.app_replace_list.txt to systemlessly replace any additional conflicting custom ROM spoof injection app paths to disable them. Changes take effect after a reboot.

--- a/app/src/main/cpp/config_path.hpp
+++ b/app/src/main/cpp/config_path.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cstdio>
+#include <string>
+#include <unistd.h>
+
+#define ORIGINAL_PROP_FILE_PATH "/data/adb/modules/unlimitedphotos/fgp.prop"
+#define DATASAVER_PROP_FILE_PATH "/data/adb/modules/unlimitedphotos/datasaver.fgp.prop"
+#define CUSTOM_PROP_FILE_PATH "/data/adb/modules/unlimitedphotos/custom.fgp.prop"
+#define CUSTOM_JSON_FILE_PATH "/data/adb/modules/unlimitedphotos/custom.fgp.json"
+#define PROFILE_FILE_PATH "/data/adb/modules/unlimitedphotos/custom.profile.prop"
+
+// Trailing whitespace in a config value ends up spoofed verbatim otherwise.
+inline void trim(std::string &str) {
+    size_t last = str.find_last_not_of(" \t\r\n");
+    if (last == std::string::npos) {
+        str.clear();
+        return;
+    }
+    str.resize(last + 1);
+    str.erase(0, str.find_first_not_of(" \t"));
+}
+
+// Parses one "key=value" line, using the same rules as the .prop -> JSON converter: skip blank
+// and comment lines, split on the first '=', truncate the value at a trailing '#' comment.
+inline std::string readPropKey(FILE *file, const char *key) {
+    if (!file) return "";
+    char lineBuf[256];
+    std::string result;
+    while (fgets(lineBuf, sizeof(lineBuf), file)) {
+        std::string line(lineBuf);
+        trim(line);
+        if (line.empty() || line[0] == '#') continue;
+        size_t equalsPos = line.find('=');
+        if (equalsPos == std::string::npos) continue;
+        std::string name = line.substr(0, equalsPos);
+        std::string value = line.substr(equalsPos + 1);
+        trim(name);
+        size_t commentPos = value.find('#');
+        if (commentPos != std::string::npos) value = value.substr(0, commentPos);
+        trim(value);
+        if (name == key) {
+            result = value;
+            break;
+        }
+    }
+    fclose(file);
+    return result;
+}
+
+inline bool configFileExists(const char *path) {
+    return access(path, F_OK) == 0;
+}
+
+inline std::string readProfileSelection() {
+    return readPropKey(fopen(PROFILE_FILE_PATH, "r"), "profile");
+}
+
+using FileExistsFn = bool (*)(const char *path);
+using ReadProfileFn = std::string (*)();
+
+// Precedence: a hand-written custom config always wins (nothing the user wrote by hand should be
+// silently overwritten by a WebUI selection); otherwise the WebUI profile picks which shipped
+// profile to load. An absent/unreadable profile file, or an unrecognised value, means "original".
+inline std::string resolveConfigPath(FileExistsFn fileExists, ReadProfileFn readProfile) {
+    if (fileExists(CUSTOM_PROP_FILE_PATH)) return CUSTOM_PROP_FILE_PATH;
+    if (fileExists(CUSTOM_JSON_FILE_PATH)) return CUSTOM_JSON_FILE_PATH;
+    if (readProfile() == "datasaver") return DATASAVER_PROP_FILE_PATH;
+    return ORIGINAL_PROP_FILE_PATH;
+}

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -9,16 +9,11 @@
 #include "zygisk.hpp"
 #include "json/single_include/nlohmann/json.hpp"
 #include "shadowhook.h"
+#include "config_path.hpp"
 
 #define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, "FGP/Native", __VA_ARGS__)
 
 #define DEX_FILE_PATH "/data/adb/modules/unlimitedphotos/classes.dex"
-
-#define PROP_FILE_PATH "/data/adb/modules/unlimitedphotos/fgp.prop"
-#define CUSTOM_PROP_FILE_PATH "/data/adb/modules/unlimitedphotos/custom.fgp.prop"
-
-#define JSON_FILE_PATH "/data/adb/modules/unlimitedphotos/fgp.json"
-#define CUSTOM_JSON_FILE_PATH "/data/adb/modules/unlimitedphotos/custom.fgp.json"
 
 #define PHOTOS_PACKAGE "com.google.android.apps.photos"
 
@@ -48,17 +43,6 @@ static bool parseInt(const std::string &str, int &out) {
     }
     out = negative ? -value : value;
     return true;
-}
-
-// Trailing whitespace in a config value ends up spoofed verbatim into a Build field otherwise.
-static void trim(std::string &str) {
-    size_t last = str.find_last_not_of(" \t");
-    if (last == std::string::npos) {
-        str.clear();
-        return;
-    }
-    str.resize(last + 1);
-    str.erase(0, str.find_first_not_of(" \t"));
 }
 
 // Reads one integer "Advanced Settings" entry, if present, then drops it from the parsed config
@@ -506,13 +490,8 @@ static void companion(int fd) {
 
     long dexSize = readFile(fopen(DEX_FILE_PATH, "rb"), dexVector);
 
-    FILE *config = fopen(CUSTOM_PROP_FILE_PATH, "r");
-    if (!config)
-        config = fopen(CUSTOM_JSON_FILE_PATH, "r");
-    if (!config)
-        config = fopen(PROP_FILE_PATH, "r");
-
-    long configSize = readFile(config, configVector);
+    std::string configPath = resolveConfigPath(configFileExists, readProfileSelection);
+    long configSize = readFile(fopen(configPath.c_str(), "r"), configVector);
 
     if (!writeFull(fd, &dexSize, sizeof(long)) || !writeFull(fd, &configSize, sizeof(long))
             || !writeFull(fd, dexVector.data(), dexSize)

--- a/module/customize.sh
+++ b/module/customize.sh
@@ -5,7 +5,7 @@ if [ -d /data/adb/modules/unlimitedphotos/system ]; then
 fi
 
 # Copy any supported custom files to updated module
-for FILE in custom.app_replace_list.txt custom.fgp.json custom.fgp.prop uninstall.sh; do
+for FILE in custom.app_replace_list.txt custom.fgp.json custom.fgp.prop custom.profile.prop uninstall.sh; do
     if [ -f "/data/adb/modules/unlimitedphotos/$FILE" ]; then
         ui_print "- Restoring $FILE"
         cp -af /data/adb/modules/unlimitedphotos/$FILE $MODPATH/$FILE

--- a/module/datasaver.fgp.prop
+++ b/module/datasaver.fgp.prop
@@ -1,0 +1,44 @@
+# The 2019 Pixel 4 XL on its final Android 13 build - unlimited "Storage saver" tier.
+# Values match the real coral factory image's build.prop (Pixel 4 XL, TP1A.221005.002.B2).
+
+# Build Fields
+MANUFACTURER=Google
+MODEL=Pixel 4 XL
+FINGERPRINT=google/coral/coral:13/TP1A.221005.002.B2/9382335:user/release-keys
+BRAND=google
+PRODUCT=coral
+DEVICE=coral
+HARDWARE=coral
+BOARD=coral
+RELEASE=13
+SDK=33
+ID=TP1A.221005.002.B2
+DISPLAY=TP1A.221005.002.B2
+INCREMENTAL=9382335
+TYPE=user
+TAGS=release-keys
+SECURITY_PATCH=2022-10-05
+DEVICE_INITIAL_SDK_INT=29
+
+# System Properties
+*.build.id=TP1A.221005.002.B2
+*.security_patch=2022-10-05
+*api_level=29
+
+# Feature Overrides
+com.google.android.feature.PIXEL_EXPERIENCE=true
+com.google.android.feature.GOOGLE_BUILD=true
+com.google.android.feature.GOOGLE_EXPERIENCE=true
+com.google.android.feature.PIXEL_2019_EXPERIENCE=true
+com.google.android.apps.photos.PIXEL_2019_PRELOAD=true
+com.google.android.apps.photos.NEXUS_PRELOAD=false
+com.google.android.apps.photos.PIXEL_PRELOAD=false
+com.google.android.apps.photos.PIXEL_2016_PRELOAD=false
+
+# Advanced Settings
+spoofBuild=1
+spoofProps=0
+spoofProvider=0
+spoofSignature=0
+spoofFeatures=1
+verboseLogs=0

--- a/module/module.prop
+++ b/module/module.prop
@@ -3,5 +3,5 @@ name=Google Photos Unlimited Backup
 version=v4
 versionCode=40000
 author=Rev4N - Credits to osm0sis & chiteroman
-description=Google Photos Unlimited Backup by Spoofing into Pixel XL.
+description=Google Photos Unlimited Backup by Spoofing into a Pixel. WebUI lets you pick Original quality (Pixel) or Data saver (Pixel 4 XL).
 updateJson=https://raw.githubusercontent.com/Rev4N1/GPhotosUnlimited/main/update.json

--- a/module/post-fs-data.sh
+++ b/module/post-fs-data.sh
@@ -1,5 +1,12 @@
 MODPATH="${0%/*}"
 
+# Snapshot which profile is taking effect this boot, before the WebUI can change
+# custom.profile.prop again, so the WebUI can tell a picked-but-not-yet-active profile
+# apart from one that is already loaded.
+PROFILE=original
+[ -f "$MODPATH/custom.profile.prop" ] && CONFIGURED=$(grep -m1 '^profile=' "$MODPATH/custom.profile.prop" | cut -d= -f2) && [ "$CONFIGURED" ] && PROFILE=$CONFIGURED
+echo "$PROFILE" > "$MODPATH/.active_profile"
+
 # Remove Google Photos from Magisk DenyList when set to Enforce in normal mode
 if magisk --denylist status; then
     magisk --denylist rm com.google.android.apps.photos

--- a/module/webroot/index.html
+++ b/module/webroot/index.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Google Photos Unlimited</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f2f2f7;
+    --card: #ffffff;
+    --text: #1c1c1e;
+    --muted: #6b6b70;
+    --accent: #1a73e8;
+    --border: #d8d8dc;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #000000;
+      --card: #1c1c1e;
+      --text: #f2f2f7;
+      --muted: #9a9a9e;
+      --accent: #4b9bff;
+      --border: #38383a;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+  }
+  main {
+    max-width: 480px;
+    margin: 0 auto;
+    padding: 24px 16px 48px;
+  }
+  h1 { font-size: 20px; margin: 8px 0 4px; }
+  p.subtitle { color: var(--muted); margin: 0 0 20px; font-size: 14px; }
+  .card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 4px 16px;
+    margin-bottom: 16px;
+  }
+  label.option {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 14px 0;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+  }
+  label.option:last-child { border-bottom: none; }
+  label.option input { margin-top: 3px; }
+  .option-text strong { display: block; font-size: 15px; }
+  .option-text span { display: block; color: var(--muted); font-size: 13px; margin-top: 2px; }
+  .notice {
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 14px 16px;
+    font-size: 13px;
+    color: var(--muted);
+    margin-bottom: 16px;
+  }
+  .status {
+    font-size: 13px;
+    color: var(--muted);
+    min-height: 18px;
+  }
+  fieldset { border: none; padding: 0; margin: 0; }
+  fieldset:disabled label.option { opacity: 0.45; cursor: not-allowed; }
+  .reboot-button {
+    display: block;
+    width: 100%;
+    margin-top: 4px;
+    padding: 12px;
+    border: none;
+    border-radius: 12px;
+    background: var(--accent);
+    color: #fff;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .reboot-button:active { opacity: 0.8; }
+  /* [hidden] and .reboot-button{display:block} have equal specificity, and author CSS beats the
+     UA stylesheet's [hidden]{display:none} in that case - so this needs to be explicit. */
+  .reboot-button[hidden] { display: none; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Google Photos Unlimited</h1>
+  <p class="subtitle">Choose which Pixel storage tier to spoof for Google Photos backup.</p>
+
+  <div id="overrideNotice" class="notice" hidden>
+    A hand-edited custom.fgp.prop or custom.fgp.json is present in the module folder, so it
+    overrides this selection. Remove it to switch profiles here.
+  </div>
+
+  <form class="card">
+    <fieldset id="profileFields">
+      <label class="option">
+        <input type="radio" name="profile" value="original">
+        <span class="option-text">
+          <strong>Original quality</strong>
+          <span>Spoofs a 2016 Pixel. Grants the unlimited "Original quality" backup tier.</span>
+        </span>
+      </label>
+      <label class="option">
+        <input type="radio" name="profile" value="datasaver">
+        <span class="option-text">
+          <strong>Data saver</strong>
+          <span>Spoofs a Pixel 4 XL. Grants the unlimited "Storage saver" backup tier.</span>
+        </span>
+      </label>
+    </fieldset>
+  </form>
+
+  <p id="status" class="status"></p>
+  <button id="rebootButton" class="reboot-button" hidden>Reboot now</button>
+</main>
+
+<script>
+const MODULE_DIR = "/data/adb/modules/unlimitedphotos";
+const PROFILE_FILE = MODULE_DIR + "/custom.profile.prop";
+const CUSTOM_PROP_FILE = MODULE_DIR + "/custom.fgp.prop";
+const CUSTOM_JSON_FILE = MODULE_DIR + "/custom.fgp.json";
+const ACTIVE_PROFILE_FILE = MODULE_DIR + "/.active_profile";
+
+const overrideNotice = document.getElementById("overrideNotice");
+const profileFields = document.getElementById("profileFields");
+const statusEl = document.getElementById("status");
+const rebootButton = document.getElementById("rebootButton");
+const radios = document.querySelectorAll('input[name="profile"]');
+
+function exec(command) {
+  return new Promise((resolve) => {
+    const callbackName = "cb" + Math.random().toString(36).slice(2);
+    window[callbackName] = (errno, stdout, stderr) => {
+      delete window[callbackName];
+      resolve({ errno, stdout, stderr });
+    };
+    ksu.exec(command, "{}", callbackName);
+  });
+}
+
+async function fileExists(path) {
+  const result = await exec(`[ -f "${path}" ] && echo yes || echo no`);
+  return result.stdout.trim() === "yes";
+}
+
+async function readProfile() {
+  const result = await exec(`grep -m1 '^profile=' "${PROFILE_FILE}" 2>/dev/null | cut -d= -f2`);
+  return result.stdout.trim();
+}
+
+// post-fs-data.sh snapshots the profile that is actually loaded this boot into
+// .active_profile before the WebUI can touch custom.profile.prop again. Comparing against that
+// (rather than just detecting "a change happened") means switching away and back within the same
+// boot correctly reports nothing pending, since the active profile never stopped matching it.
+async function readActiveProfile() {
+  const result = await exec(`cat "${ACTIVE_PROFILE_FILE}" 2>/dev/null`);
+  return result.stdout.trim() || "original";
+}
+
+async function writeProfile(profile) {
+  await exec(`printf 'profile=%s\\n' "${profile}" > "${PROFILE_FILE}"`);
+}
+
+async function rebootIsPending(desiredProfile) {
+  return (await readActiveProfile()) !== desiredProfile;
+}
+
+async function init() {
+  const [hasCustomProp, hasCustomJson, currentProfile] = await Promise.all([
+    fileExists(CUSTOM_PROP_FILE),
+    fileExists(CUSTOM_JSON_FILE),
+    readProfile(),
+  ]);
+
+  if (hasCustomProp || hasCustomJson) {
+    overrideNotice.hidden = false;
+    profileFields.disabled = true;
+    return;
+  }
+
+  const selected = currentProfile === "datasaver" ? "datasaver" : "original";
+  for (const radio of radios) {
+    radio.checked = radio.value === selected;
+  }
+
+  await refreshRebootButton();
+}
+
+// The WebUI host resumes an existing WebView instead of reloading the page when this screen is
+// reopened, so the page's lifecycle events aren't a reliable way to notice the module folder
+// changed underneath it (e.g. a soft-reboot re-snapshotting .active_profile). Poll instead of
+// depending on load/focus/visibilitychange actually firing here.
+async function refreshRebootButton() {
+  if (profileFields.disabled) return;
+  const selectedRadio = document.querySelector('input[name="profile"]:checked');
+  if (!selectedRadio) return;
+  rebootButton.hidden = !(await rebootIsPending(selectedRadio.value));
+}
+setInterval(refreshRebootButton, 2000);
+
+for (const radio of radios) {
+  radio.addEventListener("change", async (event) => {
+    await writeProfile(event.target.value);
+    await refreshRebootButton();
+  });
+}
+
+rebootButton.addEventListener("click", async () => {
+  rebootButton.disabled = true;
+  statusEl.textContent = "Rebooting…";
+  await exec("reboot");
+});
+
+init();
+</script>
+</body>
+</html>

--- a/tests/test_config_path.cpp
+++ b/tests/test_config_path.cpp
@@ -1,0 +1,65 @@
+#include <cassert>
+#include <string>
+
+#include "../app/src/main/cpp/config_path.hpp"
+
+namespace {
+
+bool g_customPropExists = false;
+bool g_customJsonExists = false;
+std::string g_profileValue;
+
+bool stubFileExists(const char *path) {
+    if (std::string(path) == CUSTOM_PROP_FILE_PATH) return g_customPropExists;
+    if (std::string(path) == CUSTOM_JSON_FILE_PATH) return g_customJsonExists;
+    return false;
+}
+
+std::string stubReadProfile() {
+    return g_profileValue;
+}
+
+void resetStubs() {
+    g_customPropExists = false;
+    g_customJsonExists = false;
+    g_profileValue.clear();
+}
+
+}  // namespace
+
+static void originalProfileSelectedByDefault() {
+    resetStubs();
+    assert(resolveConfigPath(stubFileExists, stubReadProfile) == ORIGINAL_PROP_FILE_PATH);
+}
+
+static void dataSaverProfileSelectsCoralPropFile() {
+    resetStubs();
+    g_profileValue = "datasaver";
+    assert(resolveConfigPath(stubFileExists, stubReadProfile) == DATASAVER_PROP_FILE_PATH);
+}
+
+static void handWrittenCustomConfigOverridesProfile() {
+    resetStubs();
+    g_profileValue = "datasaver";
+    g_customPropExists = true;
+    assert(resolveConfigPath(stubFileExists, stubReadProfile) == CUSTOM_PROP_FILE_PATH);
+
+    resetStubs();
+    g_profileValue = "datasaver";
+    g_customJsonExists = true;
+    assert(resolveConfigPath(stubFileExists, stubReadProfile) == CUSTOM_JSON_FILE_PATH);
+}
+
+static void unknownProfileValueFallsBackToOriginal() {
+    resetStubs();
+    g_profileValue = "not-a-real-profile";
+    assert(resolveConfigPath(stubFileExists, stubReadProfile) == ORIGINAL_PROP_FILE_PATH);
+}
+
+int main() {
+    originalProfileSelectedByDefault();
+    dataSaverProfileSelectsCoralPropFile();
+    handWrittenCustomConfigOverridesProfile();
+    unknownProfileValueFallsBackToOriginal();
+    return 0;
+}

--- a/tests/test_webui.mjs
+++ b/tests/test_webui.mjs
@@ -1,0 +1,151 @@
+// Runs the actual <script> block shipped in module/webroot/index.html inside a sandboxed VM,
+// against a mocked ksu.exec bridge (matching the real `kernelsu` npm package's
+// `ksu.exec(command, JSON.stringify(options), callbackName)` contract), so these tests exercise
+// the real shipped code rather than a reimplementation of its logic.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import vm from "node:vm";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const html = readFileSync(path.join(here, "..", "module", "webroot", "index.html"), "utf8");
+const script = html.match(/<script>([\s\S]*?)<\/script>/)[1];
+
+const MODULE_DIR = "/data/adb/modules/unlimitedphotos";
+const PROFILE_FILE = MODULE_DIR + "/custom.profile.prop";
+const CUSTOM_PROP_FILE = MODULE_DIR + "/custom.fgp.prop";
+const CUSTOM_JSON_FILE = MODULE_DIR + "/custom.fgp.json";
+const ACTIVE_PROFILE_FILE = MODULE_DIR + "/.active_profile";
+
+function makeElement(overrides = {}) {
+  return { hidden: false, disabled: false, checked: false, textContent: "", listeners: {}, addEventListener(event, fn) {
+    (this.listeners[event] ??= []).push(fn);
+  }, ...overrides };
+}
+
+// Sets up a fresh sandbox per test: a fake filesystem (`state`), a fake DOM, and a fake `ksu.exec`
+// that only understands the exact commands this page's script actually sends - not a shell.
+function runPage(state) {
+  const radios = [
+    makeElement({ value: "original" }),
+    makeElement({ value: "datasaver" }),
+  ];
+  const elements = {
+    overrideNotice: makeElement({ hidden: true }),
+    profileFields: makeElement(),
+    status: makeElement(),
+    // The real markup ships `<button ... hidden>`, so it starts hidden before any script runs.
+    rebootButton: makeElement({ hidden: true }),
+  };
+  const rebootCalls = [];
+
+  const sandbox = {
+    document: {
+      getElementById: (id) => elements[id],
+      querySelectorAll: () => radios,
+      querySelector: (selector) => {
+        assert.equal(selector, 'input[name="profile"]:checked');
+        return radios.find((r) => r.checked) ?? null;
+      },
+    },
+    window: {},
+    intervalCallbacks: [],
+    setInterval: (fn) => sandbox.intervalCallbacks.push(fn),
+    ksu: {
+      exec(command, _optionsJson, callbackName) {
+        const respond = (stdout) => sandbox.window[callbackName](0, stdout, "");
+        if (command.includes(CUSTOM_PROP_FILE)) return respond(state.hasCustomProp ? "yes" : "no");
+        if (command.includes(CUSTOM_JSON_FILE)) return respond(state.hasCustomJson ? "yes" : "no");
+        if (command.includes(ACTIVE_PROFILE_FILE)) return respond(state.active ?? "");
+        if (command.startsWith("printf")) {
+          const written = command.match(/printf 'profile=%s\\n' "([^"]*)"/)[1];
+          state.profile = written;
+          return respond("");
+        }
+        if (command.includes(PROFILE_FILE)) return respond(state.profile ?? "");
+        if (command === "reboot") {
+          rebootCalls.push(true);
+          return respond("");
+        }
+        throw new Error(`unexpected command: ${command}`);
+      },
+    },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(script, sandbox);
+
+  return { radios, elements, rebootCalls, poll: () => Promise.all(sandbox.intervalCallbacks.map((fn) => fn())) };
+}
+
+// Node's microtask queue needs a real tick for the page's chained awaits to settle before we
+// assert on DOM state, since nothing here uses fake timers.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+// A real radio group enforces mutual exclusion natively before the "change" event fires; the fake
+// DOM has no such behavior built in, so tests that click a radio must simulate it explicitly.
+async function clickRadio(radios, value) {
+  const target = radios.find((r) => r.value === value);
+  for (const radio of radios) radio.checked = radio === target;
+  await Promise.all(target.listeners.change.map((fn) => fn({ target })));
+}
+
+test("reboot button stays hidden when the selected profile is already active", async () => {
+  const { elements } = runPage({ profile: "datasaver", active: "datasaver" });
+  await flush();
+  assert.equal(elements.rebootButton.hidden, true);
+});
+
+test("reboot button shows on load when the selected profile isn't active yet", async () => {
+  const { elements } = runPage({ profile: "datasaver", active: "original" });
+  await flush();
+  assert.equal(elements.rebootButton.hidden, false);
+});
+
+test("switching to a different profile than the active one shows the reboot button", async () => {
+  const { radios, elements } = runPage({ profile: "original", active: "original" });
+  await flush();
+  assert.equal(elements.rebootButton.hidden, true);
+
+  await clickRadio(radios, "datasaver");
+  await flush();
+
+  assert.equal(elements.rebootButton.hidden, false);
+});
+
+test("switching back to the active profile hides the reboot button again", async () => {
+  const state = { profile: "original", active: "original" };
+  const { radios, elements } = runPage(state);
+  await flush();
+
+  await clickRadio(radios, "datasaver");
+  await flush();
+  assert.equal(elements.rebootButton.hidden, false);
+
+  await clickRadio(radios, "original");
+  await flush();
+  assert.equal(elements.rebootButton.hidden, true);
+});
+
+test("polling picks up an external change (e.g. a soft-reboot) without user interaction", async () => {
+  const state = { profile: "datasaver", active: "original" };
+  const { elements, poll } = runPage(state);
+  await flush();
+  assert.equal(elements.rebootButton.hidden, false);
+
+  // Simulate a soft-reboot re-snapshotting .active_profile to match the desired profile.
+  state.active = "datasaver";
+  await poll();
+  await flush();
+
+  assert.equal(elements.rebootButton.hidden, true);
+});
+
+test("a hand-written custom.fgp.prop disables the fields and never shows the reboot button", async () => {
+  const { elements } = runPage({ hasCustomProp: true, profile: "datasaver", active: "original" });
+  await flush();
+  assert.equal(elements.overrideNotice.hidden, false);
+  assert.equal(elements.profileFields.disabled, true);
+  assert.equal(elements.rebootButton.hidden, true);
+});


### PR DESCRIPTION
## What

Right now the module only spoofs one device: a 2016 Pixel, which grants the **Original quality** unlimited backup tier. This adds a second option and a way to pick between them without editing files by hand.

<img width="438" height="428" alt="image" src="https://github.com/user-attachments/assets/60a91ea7-4db3-485b-9c02-af67bd4bc832" />

## What's new

**A second spoof profile — "Data saver"**
Spoofs a Pixel 4 XL (`coral`) instead, granting the **Storage saver** unlimited tier. All values (`fingerprint`, `security_patch`, feature flags, etc.) are taken from the real coral factory `build.prop` (`TP1A.221005.002.B2`) — see `module/datasaver.fgp.prop`.

**A WebUI to switch between them**
On KernelSU, KernelSU Next, or APatch: open the module from the module list, pick "Original quality" or "Data saver". No file editing needed. (`module/webroot/index.html`)

If you already have a hand-written `custom.fgp.prop` or `custom.fgp.json` in the module folder, that keeps taking priority exactly as before — the WebUI just shows a notice and disables itself in that case.

**A "Reboot now" button, only when it's actually needed**
Switching profiles needs a reboot (the native side re-reads its config fresh every time Google Photos launches, but the profile file itself is only picked up by the root solution at the next boot). The WebUI tracks whether the profile you picked has actually taken effect yet, and only shows the reboot button when it hasn't — so switching back to the currently-active profile makes the button disappear again instead of nagging you for a reboot you don't need.

## How the pieces fit together

```
module/datasaver.fgp.prop        the new profile (mirrors fgp.prop's format)
module/webroot/index.html        the WebUI: picks a profile, shows the reboot button
module/post-fs-data.sh           snapshots which profile is actually active this boot
app/src/main/cpp/config_path.hpp resolves which .prop file the native side should load
```

Precedence, unchanged at the top: `custom.fgp.prop` → `custom.fgp.json` → (profile picked in the WebUI) → `fgp.prop` (default, unchanged behavior if you never open the WebUI).

## Testing

- `tests/test_config_path.cpp` — covers the profile-resolution precedence above
- `tests/test_webui.mjs` — runs the actual `<script>` shipped in `index.html` (not a reimplementation) inside a sandboxed Node VM against a mocked root-shell bridge, covering: initial load, switching profiles, switching back, and an external state change (e.g. a reboot) updating the button on its own
- Both run in CI: [passing run](https://github.com/Ch4s3r/GPhotosUnlimited/actions/runs/34280169845)
- Manually verified end-to-end on a rooted Pixel 8 Pro (APatch + Zygisk Next): installed the module, confirmed via `logcat | grep FGP` that each profile spoofs the correct Build fields/fingerprint, and confirmed the WebUI's reboot button behaves correctly across profile switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)